### PR TITLE
Automated PCB Image generation

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -1,0 +1,44 @@
+name: images
+on:
+  push:
+jobs:
+  render-images:
+    name: render-images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: render pcb images
+        uses: linalinn/kicad-render@main
+        with:
+          pcb_file: m2sdr.kicad_pcb
+          output_path: ${{ github.workspace }}/images
+          
+      - name: Setup Pages
+        if: github.ref == 'refs/heads/master'
+        uses: actions/configure-pages@v3
+
+      - name: Upload Artifact
+        if: github.ref == 'refs/heads/master'
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: "images"
+
+  deploy-pages:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs: render-images
+    
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # M2SDR
 
 ## Images
-![top](hackmodsorg.github.io/m2sdr/images/top.png)
-![bottom](hackmodsorg.github.io/m2sdr/images/bottom.png)
+![top](hackmodsorg.github.io/m2sdr/top.png)
+![bottom](hackmodsorg.github.io/m2sdr/bottom.png)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# M2SDR
+
+## Images
+![top](hackmodsorg.github.io/m2sdr/images/top.png)
+![bottom](hackmodsorg.github.io/m2sdr/images/bottom.png)


### PR DESCRIPTION
This MR adds an github workflow that renders Images of the PCB every time a commit is pushed

Note: the Images are going to show up once the first github actions run successfully.

Also it maybe need to configure github pages to use github actions for deployments [see](https://github.com/linalinn/kicad-render?tab=readme-ov-file#usage)